### PR TITLE
Removed HTML from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,3 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
-
-# HTML reports
-*.html


### PR DESCRIPTION
HTML is not needed in the gitignore.. The generated report_PS03.html file will be generated in PS03/bin/Debug, which is where the program exe file is. The entire bin/ folder is ignored, which means the HTML file inside is as well..
